### PR TITLE
Added ROS parameter for IP configuration

### DIFF
--- a/unitree_legged_real/launch/real.launch
+++ b/unitree_legged_real/launch/real.launch
@@ -1,7 +1,9 @@
 <launch>
     <arg name="ctrl_level" default="highlevel"/>
+    <arg name="udp_ip" default="192.168.123.161"/>
 
     <node pkg="unitree_legged_real" type="ros_udp" name="node_ros_udp" output="screen" args="$(arg ctrl_level)"/>
 
     <param name="control_level" value="$(arg ctrl_level)"/>
+    <param name="/UDP_IP" value="$(arg udp_ip)"/>
 </launch>

--- a/unitree_legged_real/src/exe/ros_udp.cpp
+++ b/unitree_legged_real/src/exe/ros_udp.cpp
@@ -8,8 +8,12 @@
 #include <chrono>
 #include <pthread.h>
 #include <geometry_msgs/Twist.h>
+#include <string>
 
 using namespace UNITREE_LEGGED_SDK;
+
+std::string udp_ip;
+
 class Custom
 {
 public:
@@ -25,7 +29,7 @@ public:
 public:
     Custom()
         : low_udp(LOWLEVEL),
-          high_udp(8090, "192.168.123.161", 8082, sizeof(HighCmd), sizeof(HighState))
+          high_udp(8090, udp_ip, 8082, sizeof(HighCmd), sizeof(HighState))
     {
         high_udp.InitCmdData(high_cmd);
         low_udp.InitCmdData(low_cmd);
@@ -109,6 +113,12 @@ int main(int argc, char **argv)
     ros::init(argc, argv, "ros_udp");
 
     ros::NodeHandle nh;
+
+    nh.param<std::string>("/UDP_IP", udp_ip, "192.168.123.161");
+    custom = new Custom();
+
+    printf("Parameter /UDP_IP: %s\n", udp_ip);
+
 
     if (strcasecmp(argv[1], "LOWLEVEL") == 0)
     {

--- a/unitree_legged_real/src/exe/ros_udp.cpp
+++ b/unitree_legged_real/src/exe/ros_udp.cpp
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
 
     custom = Custom();
 
-    printf("Parameter /UDP_IP: %s\n", udp_ip);
+    printf("Parameter /UDP_IP: %s%s\n", udp_ip, nh.hasParam("/UDP_IP") ? "" : " (as default value)");
 
 
     if (strcasecmp(argv[1], "LOWLEVEL") == 0)

--- a/unitree_legged_real/src/exe/ros_udp.cpp
+++ b/unitree_legged_real/src/exe/ros_udp.cpp
@@ -29,7 +29,7 @@ public:
 public:
     Custom()
         : low_udp(LOWLEVEL),
-          high_udp(8090, udp_ip, 8082, sizeof(HighCmd), sizeof(HighState))
+          high_udp(8090, const_cast<const char*>(udp_ip), 8082, sizeof(HighCmd), sizeof(HighState))
     {
         high_udp.InitCmdData(high_cmd);
         low_udp.InitCmdData(low_cmd);
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
 
     ros::NodeHandle nh;
 
-    nh.param<char*>("/UDP_IP", const_cast<const char*>(udp_ip), "192.168.123.161");
+    nh.param<char*>("/UDP_IP", udp_ip, "192.168.123.161");
     custom = new Custom();
 
     printf("Parameter /UDP_IP: %s\n", udp_ip);

--- a/unitree_legged_real/src/exe/ros_udp.cpp
+++ b/unitree_legged_real/src/exe/ros_udp.cpp
@@ -114,10 +114,10 @@ int main(int argc, char **argv)
 
     ros::NodeHandle nh;
 
-    nh.param<std::string>("/UDP_IP", udp_ip, "192.168.123.161");
+    nh.param<std::string>("/UDP_IP", udp_ip.c_str(), "192.168.123.161");
     custom = new Custom();
 
-    printf("Parameter /UDP_IP: %s\n", udp_ip);
+    printf("Parameter /UDP_IP: %s\n", udp_ip.c_str());
 
 
     if (strcasecmp(argv[1], "LOWLEVEL") == 0)

--- a/unitree_legged_real/src/exe/ros_udp.cpp
+++ b/unitree_legged_real/src/exe/ros_udp.cpp
@@ -118,7 +118,7 @@ int main(int argc, char **argv)
     nh.param<std::string>("/UDP_IP", ip_string, "192.168.123.161");
     strcpy(udp_ip, ip_string.c_str());
 
-    custom = new Custom();
+    custom = Custom();
 
     printf("Parameter /UDP_IP: %s\n", udp_ip);
 

--- a/unitree_legged_real/src/exe/ros_udp.cpp
+++ b/unitree_legged_real/src/exe/ros_udp.cpp
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
     nh.param<char*>("/UDP_IP", const_cast<const char*>(udp_ip), "192.168.123.161");
     custom = new Custom();
 
-    printf("Parameter /UDP_IP: %s\n", udp_ip.c_str());
+    printf("Parameter /UDP_IP: %s\n", udp_ip);
 
 
     if (strcasecmp(argv[1], "LOWLEVEL") == 0)

--- a/unitree_legged_real/src/exe/ros_udp.cpp
+++ b/unitree_legged_real/src/exe/ros_udp.cpp
@@ -12,7 +12,7 @@
 
 using namespace UNITREE_LEGGED_SDK;
 
-std::string udp_ip;
+char udp_ip[16];
 
 class Custom
 {
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
 
     ros::NodeHandle nh;
 
-    nh.param<std::string>("/UDP_IP", udp_ip.c_str(), "192.168.123.161");
+    nh.param<char*>("/UDP_IP", const_cast<const char*>(udp_ip), "192.168.123.161");
     custom = new Custom();
 
     printf("Parameter /UDP_IP: %s\n", udp_ip.c_str());

--- a/unitree_legged_real/src/exe/ros_udp.cpp
+++ b/unitree_legged_real/src/exe/ros_udp.cpp
@@ -114,7 +114,10 @@ int main(int argc, char **argv)
 
     ros::NodeHandle nh;
 
-    nh.param<char*>("/UDP_IP", udp_ip, "192.168.123.161");
+    std::string ip_string;
+    nh.param<std::string>("/UDP_IP", ip_string, "192.168.123.161");
+    strcpy(udp_ip, ip_string.c_str());
+
     custom = new Custom();
 
     printf("Parameter /UDP_IP: %s\n", udp_ip);


### PR DESCRIPTION
The parameter `/UDP_IP` can now be set to the UDP destination address.
The `real.launch` file now accepts an argument `udp_ip` to set this parameter